### PR TITLE
Pass an extra flag, `allow_val_change=True`, when updating config in wandb

### DIFF
--- a/ml_logger/logger/wandb.py
+++ b/ml_logger/logger/wandb.py
@@ -65,4 +65,4 @@ class Logger(BaseLogger):
         Args:
             config (ConfigType): Config to write
         """
-        wandb.config.update(config)
+        wandb.config.update(config, allow_val_change=True)


### PR DESCRIPTION
Fixes #74

Note that `allow_val_change=True` is not documented in wandb documentation.